### PR TITLE
Change HttpResponse mimetype kwarg to content_type. Django 1.7 fix.

### DIFF
--- a/django_cal/views.py
+++ b/django_cal/views.py
@@ -72,7 +72,7 @@ class Events(object):
             raise Http404('Events object does not exist.')
         ical = self.get_ical(obj, request)
         response = HttpResponse(ical.serialize(),
-            mimetype='text/calendar;charset=' + settings.DEFAULT_CHARSET)
+            content_type='text/calendar;charset=' + settings.DEFAULT_CHARSET)
         filename = self.__get_dynamic_attr('filename', obj)
         # following added for IE, see
         # http://blog.thescoop.org/archives/2007/07/31/django-ical-and-vobject/


### PR DESCRIPTION
HttpResponse's mimetype kwarg has been deprecated for about three years now.  Django 1.7 completed the removal, which means django-cal no longer works on 1.7 installs.

This patch switches to the new content_type kwarg, which works identically to the old mimetype kwarg. This was a straight up rename.
